### PR TITLE
chore(docker): reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG DEBIAN_VERSION="bullseye"
-
-FROM wakemeops/debian:${DEBIAN_VERSION}-slim
+FROM wakemeops/minideb:latest
 WORKDIR /shared
 
 RUN install_packages xh && \


### PR DESCRIPTION
Start from wakemeops/minideb image

```console
REPOSITORY            TAG       IMAGE ID       CREATED         SIZE
upciti/quitquitquit   minideb   7be7e40d8c4c   3 seconds ago   75.6MB
upciti/quitquitquit   latest    a1527a5fc6cd   6 weeks ago     97.7MB
```